### PR TITLE
Add nesting functionality and adoption flexibility

### DIFF
--- a/json_schema/Disclosures.schema.json
+++ b/json_schema/Disclosures.schema.json
@@ -514,7 +514,6 @@
   },
   "required": [
     "project",
-    "project_stakeholder",
-    "registry"
+    "project_stakeholder"
   ]
 }

--- a/json_schema/Disclosures.schema.json
+++ b/json_schema/Disclosures.schema.json
@@ -511,5 +511,10 @@
       },
       "required": []
     }
-  }
+  },
+  "required": [
+    "project",
+    "project_stakeholder",
+    "registry"
+  ]
 }

--- a/json_schema/Disclosures.schema.json
+++ b/json_schema/Disclosures.schema.json
@@ -511,9 +511,5 @@
       },
       "required": []
     }
-  },
-  "required": [
-    "project",
-    "project_stakeholder"
-  ]
+  }
 }

--- a/json_schema/Disclosures.schema.json
+++ b/json_schema/Disclosures.schema.json
@@ -3,11 +3,11 @@
   "$id": "Disclosures.schema.json",
   "title": "Disclosures",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "project": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "attestations": {
           "type": "array",
@@ -266,7 +266,7 @@
     },
     "project_stakeholder": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "list_of_landowners": {
           "type": "array",
@@ -434,7 +434,7 @@
     },
     "registry": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "previous_project_crediting_program_name": {
           "type": "array",

--- a/json_schema/Full_List.schema.json
+++ b/json_schema/Full_List.schema.json
@@ -2027,14 +2027,9 @@
     }
   },
   "required": [
-    "crediting_program",
-    "facility",
     "geolocation_file",
     "issuance",
-    "methodology",
     "project",
-    "project_stakeholder",
-    "registry",
-    "validation"
+    "project_stakeholder"
   ]
 }

--- a/json_schema/Full_List.schema.json
+++ b/json_schema/Full_List.schema.json
@@ -2025,5 +2025,16 @@
         "forecast_year"
       ]
     }
-  }
+  },
+  "required": [
+    "crediting_program",
+    "facility",
+    "geolocation_file",
+    "issuance",
+    "methodology",
+    "project",
+    "project_stakeholder",
+    "registry",
+    "validation"
+  ]
 }

--- a/json_schema/Full_List.schema.json
+++ b/json_schema/Full_List.schema.json
@@ -437,7 +437,7 @@
           },
           "minItems": 0
         },
-        "project_Identifier": {
+        "project_identifier": {
           "type": "string",
           "description": "Global unique identifier for the project",
           "x-cdop-field-id": 88,
@@ -894,6 +894,21 @@
             "x-cdop-pre-issuance-inclusion": "yes",
             "x-cdop-cardinality": "0..*",
             "x-cdop-data-source": "project developer",
+            "x-cdop-mutability": "immutable",
+            "x-cdop-public-private": "private",
+            "x-cdop-schema": "CDOP"
+          },
+          "minItems": 0
+        },
+        "country_subdivision_code": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
+            "x-cdop-field-id": 23,
+            "x-cdop-pre-issuance-inclusion": "yes",
+            "x-cdop-cardinality": "0..*",
+            "x-cdop-data-source": "project developer, registry",
             "x-cdop-mutability": "immutable",
             "x-cdop-public-private": "private",
             "x-cdop-schema": "CDOP"
@@ -1403,28 +1418,6 @@
       },
       "required": []
     },
-    "project stakeholder": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "country_subdivision_code": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
-            "x-cdop-field-id": 23,
-            "x-cdop-pre-issuance-inclusion": "yes",
-            "x-cdop-cardinality": "0..*",
-            "x-cdop-data-source": "project developer, registry",
-            "x-cdop-mutability": "immutable",
-            "x-cdop-public-private": "private",
-            "x-cdop-schema": "CDOP"
-          },
-          "minItems": 0
-        }
-      },
-      "required": []
-    },
     "geolocation_file": {
       "type": "object",
       "additionalProperties": true,
@@ -1894,7 +1887,7 @@
           },
           "minItems": 1
         },
-        "batch_Identifier": {
+        "batch_identifier": {
           "type": "array",
           "items": {
             "type": "string",

--- a/json_schema/Full_List.schema.json
+++ b/json_schema/Full_List.schema.json
@@ -437,7 +437,7 @@
           },
           "minItems": 0
         },
-        "project_identifier": {
+        "project_Identifier": {
           "type": "string",
           "description": "Global unique identifier for the project",
           "x-cdop-field-id": 88,
@@ -894,21 +894,6 @@
             "x-cdop-pre-issuance-inclusion": "yes",
             "x-cdop-cardinality": "0..*",
             "x-cdop-data-source": "project developer",
-            "x-cdop-mutability": "immutable",
-            "x-cdop-public-private": "private",
-            "x-cdop-schema": "CDOP"
-          },
-          "minItems": 0
-        },
-        "country_subdivision_code": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
-            "x-cdop-field-id": 23,
-            "x-cdop-pre-issuance-inclusion": "yes",
-            "x-cdop-cardinality": "0..*",
-            "x-cdop-data-source": "project developer, registry",
             "x-cdop-mutability": "immutable",
             "x-cdop-public-private": "private",
             "x-cdop-schema": "CDOP"
@@ -1418,6 +1403,28 @@
       },
       "required": []
     },
+    "project stakeholder": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "country_subdivision_code": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
+            "x-cdop-field-id": 23,
+            "x-cdop-pre-issuance-inclusion": "yes",
+            "x-cdop-cardinality": "0..*",
+            "x-cdop-data-source": "project developer, registry",
+            "x-cdop-mutability": "immutable",
+            "x-cdop-public-private": "private",
+            "x-cdop-schema": "CDOP"
+          },
+          "minItems": 0
+        }
+      },
+      "required": []
+    },
     "geolocation_file": {
       "type": "object",
       "additionalProperties": false,
@@ -1887,7 +1894,7 @@
           },
           "minItems": 1
         },
-        "batch_identifier": {
+        "batch_Identifier": {
           "type": "array",
           "items": {
             "type": "string",
@@ -2025,11 +2032,5 @@
         "forecast_year"
       ]
     }
-  },
-  "required": [
-    "geolocation_file",
-    "issuance",
-    "project",
-    "project_stakeholder"
-  ]
+  }
 }

--- a/json_schema/Full_List.schema.json
+++ b/json_schema/Full_List.schema.json
@@ -3,11 +3,11 @@
   "$id": "Full_List.schema.json",
   "title": "Full List",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "project": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_code": {
           "type": "array",
@@ -793,7 +793,7 @@
     },
     "project_stakeholder": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_code": {
           "type": "array",
@@ -1233,7 +1233,7 @@
     },
     "facility": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_code": {
           "type": "array",
@@ -1405,7 +1405,7 @@
     },
     "project stakeholder": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_subdivision_code": {
           "type": "array",
@@ -1427,7 +1427,7 @@
     },
     "geolocation_file": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "file_name": {
           "type": "string",
@@ -1554,7 +1554,7 @@
     },
     "crediting_program": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "crediting_program_name": {
           "type": "array",
@@ -1613,7 +1613,7 @@
     },
     "methodology": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "methodology": {
           "type": "array",
@@ -1680,7 +1680,7 @@
     },
     "registry": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "origin_registry": {
           "type": "string",
@@ -1781,7 +1781,7 @@
     },
     "validation": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "validation_body_name": {
           "type": "string",
@@ -1822,7 +1822,7 @@
     },
     "issuance": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "forecast_annual_issuance": {
           "type": "array",

--- a/json_schema/Issuances.schema.json
+++ b/json_schema/Issuances.schema.json
@@ -315,7 +315,6 @@
     }
   },
   "required": [
-    "issuance",
-    "project"
+    "issuance"
   ]
 }

--- a/json_schema/Issuances.schema.json
+++ b/json_schema/Issuances.schema.json
@@ -3,11 +3,11 @@
   "$id": "Issuances.schema.json",
   "title": "Issuances",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "issuance": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "forecast_annual_issuance": {
           "type": "array",
@@ -219,7 +219,7 @@
     },
     "project": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "project_Identifier": {
           "type": "string",

--- a/json_schema/Issuances.schema.json
+++ b/json_schema/Issuances.schema.json
@@ -313,5 +313,9 @@
       },
       "required": []
     }
-  }
+  },
+  "required": [
+    "issuance",
+    "project"
+  ]
 }

--- a/json_schema/Issuances.schema.json
+++ b/json_schema/Issuances.schema.json
@@ -79,7 +79,7 @@
           },
           "minItems": 1
         },
-        "batch_Identifier": {
+        "batch_identifier": {
           "type": "array",
           "items": {
             "type": "string",
@@ -221,7 +221,7 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
-        "project_Identifier": {
+        "project_identifier": {
           "type": "string",
           "description": "Global unique identifier for the project",
           "x-cdop-field-id": 88,

--- a/json_schema/Issuances.schema.json
+++ b/json_schema/Issuances.schema.json
@@ -79,7 +79,7 @@
           },
           "minItems": 1
         },
-        "batch_identifier": {
+        "batch_Identifier": {
           "type": "array",
           "items": {
             "type": "string",
@@ -221,7 +221,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "project_identifier": {
+        "project_Identifier": {
           "type": "string",
           "description": "Global unique identifier for the project",
           "x-cdop-field-id": 88,
@@ -313,8 +313,5 @@
       },
       "required": []
     }
-  },
-  "required": [
-    "issuance"
-  ]
+  }
 }

--- a/json_schema/Location_Details.schema.json
+++ b/json_schema/Location_Details.schema.json
@@ -293,6 +293,21 @@
           },
           "minItems": 0
         },
+        "country_subdivision_code": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
+            "x-cdop-field-id": 23,
+            "x-cdop-pre-issuance-inclusion": "yes",
+            "x-cdop-cardinality": "0..*",
+            "x-cdop-data-source": "project developer, registry",
+            "x-cdop-mutability": "immutable",
+            "x-cdop-public-private": "private",
+            "x-cdop-schema": "CDOP"
+          },
+          "minItems": 0
+        },
         "country_subdivision_name": {
           "type": "array",
           "items": {
@@ -504,28 +519,6 @@
             "type": "string",
             "description": "The postal code where the facility is located",
             "x-cdop-field-id": 33,
-            "x-cdop-pre-issuance-inclusion": "yes",
-            "x-cdop-cardinality": "0..*",
-            "x-cdop-data-source": "project developer, registry",
-            "x-cdop-mutability": "immutable",
-            "x-cdop-public-private": "private",
-            "x-cdop-schema": "CDOP"
-          },
-          "minItems": 0
-        }
-      },
-      "required": []
-    },
-    "project stakeholder": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "country_subdivision_code": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
-            "x-cdop-field-id": 23,
             "x-cdop-pre-issuance-inclusion": "yes",
             "x-cdop-cardinality": "0..*",
             "x-cdop-data-source": "project developer, registry",

--- a/json_schema/Location_Details.schema.json
+++ b/json_schema/Location_Details.schema.json
@@ -293,21 +293,6 @@
           },
           "minItems": 0
         },
-        "country_subdivision_code": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
-            "x-cdop-field-id": 23,
-            "x-cdop-pre-issuance-inclusion": "yes",
-            "x-cdop-cardinality": "0..*",
-            "x-cdop-data-source": "project developer, registry",
-            "x-cdop-mutability": "immutable",
-            "x-cdop-public-private": "private",
-            "x-cdop-schema": "CDOP"
-          },
-          "minItems": 0
-        },
         "country_subdivision_name": {
           "type": "array",
           "items": {
@@ -531,6 +516,28 @@
       },
       "required": []
     },
+    "project stakeholder": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "country_subdivision_code": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "ISO 3166-2 country subdivision code of where the project stakeholder has their headquarters",
+            "x-cdop-field-id": 23,
+            "x-cdop-pre-issuance-inclusion": "yes",
+            "x-cdop-cardinality": "0..*",
+            "x-cdop-data-source": "project developer, registry",
+            "x-cdop-mutability": "immutable",
+            "x-cdop-public-private": "private",
+            "x-cdop-schema": "CDOP"
+          },
+          "minItems": 0
+        }
+      },
+      "required": []
+    },
     "geolocation_file": {
       "type": "object",
       "additionalProperties": false,
@@ -658,10 +665,5 @@
         "validity_start_date"
       ]
     }
-  },
-  "required": [
-    "geolocation_file",
-    "project",
-    "project_stakeholder"
-  ]
+  }
 }

--- a/json_schema/Location_Details.schema.json
+++ b/json_schema/Location_Details.schema.json
@@ -658,5 +658,11 @@
         "validity_start_date"
       ]
     }
-  }
+  },
+  "required": [
+    "facility",
+    "geolocation_file",
+    "project",
+    "project_stakeholder"
+  ]
 }

--- a/json_schema/Location_Details.schema.json
+++ b/json_schema/Location_Details.schema.json
@@ -660,7 +660,6 @@
     }
   },
   "required": [
-    "facility",
     "geolocation_file",
     "project",
     "project_stakeholder"

--- a/json_schema/Location_Details.schema.json
+++ b/json_schema/Location_Details.schema.json
@@ -3,11 +3,11 @@
   "$id": "Location_Details.schema.json",
   "title": "Location Details",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "project": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_code": {
           "type": "array",
@@ -186,7 +186,7 @@
     },
     "project_stakeholder": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_code": {
           "type": "array",
@@ -346,7 +346,7 @@
     },
     "facility": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_code": {
           "type": "array",
@@ -518,7 +518,7 @@
     },
     "project stakeholder": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "country_subdivision_code": {
           "type": "array",
@@ -540,7 +540,7 @@
     },
     "geolocation_file": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "file_name": {
           "type": "string",

--- a/json_schema/Project_Approach_Details.schema.json
+++ b/json_schema/Project_Approach_Details.schema.json
@@ -604,9 +604,5 @@
       },
       "required": []
     }
-  },
-  "required": [
-    "project",
-    "project_stakeholder"
-  ]
+  }
 }

--- a/json_schema/Project_Approach_Details.schema.json
+++ b/json_schema/Project_Approach_Details.schema.json
@@ -606,11 +606,7 @@
     }
   },
   "required": [
-    "crediting_program",
-    "methodology",
     "project",
-    "project_stakeholder",
-    "registry",
-    "validation"
+    "project_stakeholder"
   ]
 }

--- a/json_schema/Project_Approach_Details.schema.json
+++ b/json_schema/Project_Approach_Details.schema.json
@@ -3,11 +3,11 @@
   "$id": "Project_Approach_Details.schema.json",
   "title": "Project Approach & Details",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "crediting_program": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "crediting_program_name": {
           "type": "array",
@@ -66,7 +66,7 @@
     },
     "methodology": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "methodology": {
           "type": "array",
@@ -133,7 +133,7 @@
     },
     "project": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "project_name": {
           "type": "string",
@@ -408,7 +408,7 @@
     },
     "project_stakeholder": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "project_developer_name": {
           "type": "string",
@@ -536,7 +536,7 @@
     },
     "registry": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "origin_registry": {
           "type": "string",
@@ -565,7 +565,7 @@
     },
     "validation": {
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "validation_body_name": {
           "type": "string",

--- a/json_schema/Project_Approach_Details.schema.json
+++ b/json_schema/Project_Approach_Details.schema.json
@@ -604,5 +604,13 @@
       },
       "required": []
     }
-  }
+  },
+  "required": [
+    "crediting_program",
+    "methodology",
+    "project",
+    "project_stakeholder",
+    "registry",
+    "validation"
+  ]
 }

--- a/json_schema_legacy/migration-guide.md
+++ b/json_schema_legacy/migration-guide.md
@@ -48,15 +48,15 @@ The new schemas are organized by entity sections such as:
 
 If your current API or validation flow flattens fields into a single object, you will need a transformation layer that groups fields into the required entity object.
 
-### 3. `additionalProperties: false` is enforced broadly
+### 3. `additionalProperties: true` is set broadly — additional properties are permitted
 
-The generated schemas disallow undeclared properties at the top level and inside each entity object. This is important for API frameworks that previously accepted pass-through fields.
+The generated schemas allow undeclared properties at the top level and inside each entity object. API frameworks and validators will accept pass-through fields without errors.
 
 Recommended action:
 
-- reject unknown fields before submission, or
-- strip unknown fields in a preprocessing step, or
-- map internal-only fields to a separate non-CDOP payload
+- additional fields in your payload will not cause validation failures
+- a set prefix may be useful for your own documentation, but is not required
+- you may still want to document or constrain extra fields in your own application logic if stricter control is needed
 
 ### 4. Required top-level objects are now enforced
 
@@ -163,7 +163,6 @@ Examples:
 
 - switching to the new file name
 - honoring required top-level objects
-- honoring `additionalProperties: false`
 - consuming the `x-cdop-*` annotations if useful
 
 ### Required top-level objects
@@ -465,7 +464,7 @@ Business validation is still useful for:
 - Update schema file references to `json_schema/*.schema.json`.
 - Regenerate typed models or DTOs from the new schema files.
 - Add or update a transformation layer from legacy payload shape to new CDOP payload shape.
-- Enforce `additionalProperties: false` handling.
+- Note that `additionalProperties: true` is set — extra fields in payloads will not cause schema validation failures.
 - Ensure required top-level entity objects are present.
 - Move renamed and relocated fields to their new entity sections.
 - Convert legacy arrays of objects into aligned CDOP arrays where required.

--- a/json_schema_legacy/migration-guide.md
+++ b/json_schema_legacy/migration-guide.md
@@ -55,7 +55,7 @@ The generated schemas allow undeclared properties at the top level and inside ea
 Recommended action:
 
 - additional fields in your payload will not cause validation failures
-- a set prefix may be useful for your own documentation, but is not required
+- a prefix may be useful for your own documentation, but is not required
 - you may still want to document or constrain extra fields in your own application logic if stricter control is needed
 
 ### 4. Required top-level objects are now enforced

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -298,7 +298,7 @@ def add_parent_field_property(root_schema, record):
             "type": "array",
             "items": {
                 "type": "object",
-                "additionalProperties": False,
+                "additionalProperties": True,
                 "properties": {},
                 "required": [],
             },

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -4,21 +4,8 @@ import re
 from openpyxl import load_workbook
 
 
-# Current Mapping
-'''
-associated_entity → object
-field_name → property
-definition → description
-datatype → type
-cardinality → scalar vs array
-required_optional → required fields
-
-'''
-
-
 INPUT_FILE = "docs/CDOP_SCHEMA.xlsx"
 OUTPUT_DIR = "json_schema"
-
 JSON_SCHEMA_VERSION = "https://json-schema.org/draft/2020-12/schema"
 
 
@@ -36,6 +23,8 @@ TYPE_MAP = {
     "bool": "boolean",
     "date": "string",
     "datetime": "string",
+    "object": "object",
+    "array": "array",
 }
 
 
@@ -56,11 +45,9 @@ def normalize_header(value):
 def clean_value(value):
     if value is None:
         return None
-
     if isinstance(value, str):
         value = value.strip()
         return value or None
-
     return value
 
 
@@ -70,40 +57,25 @@ def safe_filename(value):
     return value.strip("_") or "schema"
 
 
-def normalize_schema_key(value):
-    if value is None:
-        return ""
-
-    value = str(value).strip().lower()
-    value = re.sub(r"[^a-z0-9]+", "_", value)
-    return value.strip("_")
-
-
 def map_type(datatype):
     if datatype is None:
         return "string"
-
-    key = str(datatype).strip().lower()
-    return TYPE_MAP.get(key, "string")
+    return TYPE_MAP.get(str(datatype).strip().lower(), "string")
 
 
 def map_format(datatype):
     if datatype is None:
         return None
+    return FORMAT_MAP.get(str(datatype).strip().lower())
 
-    key = str(datatype).strip().lower()
-    return FORMAT_MAP.get(key)
+
+def is_required(value):
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"required", "yes", "y", "true", "1"}
 
 
 def parse_enum_values(value):
-    """
-    Optional hook for a future Excel column named enum_values.
-
-    Supports:
-    - USA|CAN|MEX
-    - USA, CAN, MEX
-    - USA; CAN; MEX
-    """
     if not value:
         return None
 
@@ -121,39 +93,19 @@ def parse_enum_values(value):
 
 
 def parse_cardinality(cardinality):
-    """
-    Converts cardinality values into array/scalar behavior.
-
-    Examples:
-    1      → scalar, required handled separately
-    0..1   → scalar, optional handled separately
-    1..*   → array, minItems 1
-    0..*   → array
-    2..*   → array, minItems 2
-    1..5   → array, minItems 1, maxItems 5
-    """
     if cardinality is None:
-        return {
-            "is_array": False,
-            "min_items": None,
-            "max_items": None,
-        }
+        return {"is_array": False, "min_items": None, "max_items": None}
 
     value = str(cardinality).strip()
 
     if ".." not in value:
-        return {
-            "is_array": False,
-            "min_items": None,
-            "max_items": None,
-        }
+        return {"is_array": False, "min_items": None, "max_items": None}
 
     lower, upper = [part.strip() for part in value.split("..", 1)]
 
     min_items = int(lower) if lower.isdigit() else None
     max_items = None if upper == "*" else int(upper) if upper.isdigit() else None
-
-    is_array = upper == "*" or upper.isdigit() and int(upper) > 1
+    is_array = upper == "*" or (upper.isdigit() and int(upper) > 1)
 
     return {
         "is_array": is_array,
@@ -162,26 +114,7 @@ def parse_cardinality(cardinality):
     }
 
 
-def is_required(value):
-    if value is None:
-        return False
-
-    return str(value).strip().lower() in {
-        "required",
-        "yes",
-        "y",
-        "true",
-        "1",
-    }
-
-
 def add_custom_annotations(field_schema, record):
-    """
-    Preserve governance metadata as non-validation annotations.
-
-    JSON Schema allows extension keywords. Prefixing with x-cdop-
-    makes it clear these are custom project-specific annotations.
-    """
     annotation_fields = {
         "field_id": "x-cdop-field-id",
         "pre_issuance_inclusion": "x-cdop-pre-issuance-inclusion",
@@ -190,6 +123,9 @@ def add_custom_annotations(field_schema, record):
         "mutability": "x-cdop-mutability",
         "public_private": "x-cdop-public-private",
         "schema": "x-cdop-schema",
+        "parent_field": "x-cdop-parent-field",
+        "item_type": "x-cdop-item-type",
+        "field_path": "x-cdop-field-path",
     }
 
     for source_key, target_key in annotation_fields.items():
@@ -200,24 +136,19 @@ def add_custom_annotations(field_schema, record):
 
 def build_base_field_schema(record):
     datatype = record.get("datatype")
-    definition = record.get("definition")
+    datatype_key = str(datatype).strip().lower() if datatype else None
 
-    field_schema = {
-        "type": map_type(datatype)
-    }
+    field_schema = {"type": map_type(datatype)}
 
     json_format = map_format(datatype)
     if json_format:
         field_schema["format"] = json_format
 
-    if definition:
-        field_schema["description"] = definition
-
-    datatype_key = str(datatype).strip().lower() if datatype else None
+    if record.get("definition"):
+        field_schema["description"] = record["definition"]
 
     if datatype_key == "enum":
         field_schema["type"] = "string"
-
         enum_values = parse_enum_values(record.get("enum_values"))
         if enum_values:
             field_schema["enum"] = enum_values
@@ -227,55 +158,173 @@ def build_base_field_schema(record):
     return field_schema
 
 
+def wrap_for_cardinality(field_schema, record):
+    cardinality_info = parse_cardinality(record.get("cardinality"))
+
+    if not cardinality_info["is_array"]:
+        return field_schema
+
+    array_schema = {
+        "type": "array",
+        "items": field_schema,
+    }
+
+    if cardinality_info["min_items"] is not None:
+        array_schema["minItems"] = cardinality_info["min_items"]
+
+    if cardinality_info["max_items"] is not None:
+        array_schema["maxItems"] = cardinality_info["max_items"]
+
+    return array_schema
+
+
 def build_field_schema(record):
     base_schema = build_base_field_schema(record)
 
-    cardinality_info = parse_cardinality(record.get("cardinality"))
+    datatype = str(record.get("datatype")).strip().lower() if record.get("datatype") else None
+    item_type = str(record.get("item_type")).strip().lower() if record.get("item_type") else None
 
-    if cardinality_info["is_array"]:
-        array_schema = {
-            "type": "array",
-            "items": base_schema,
+    if datatype == "array" and item_type == "object":
+        base_schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {},
+            "required": [],
         }
 
-        if cardinality_info["min_items"] is not None:
-            array_schema["minItems"] = cardinality_info["min_items"]
+    return wrap_for_cardinality(base_schema, record)
 
-        if cardinality_info["max_items"] is not None:
-            array_schema["maxItems"] = cardinality_info["max_items"]
 
+def ensure_object_property(parent_schema, property_name):
+    props = parent_schema.setdefault("properties", {})
+
+    if property_name not in props:
+        props[property_name] = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {},
+            "required": [],
+        }
+
+    return props[property_name]
+
+
+def add_required(parent_schema, property_name):
+    required = parent_schema.setdefault("required", [])
+    if property_name not in required:
+        required.append(property_name)
+        required.sort()
+
+
+def get_array_items_schema(array_schema):
+    if array_schema.get("type") != "array":
         return array_schema
 
-    return base_schema
+    items = array_schema.setdefault("items", {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {},
+        "required": [],
+    })
+
+    return items
 
 
-def register_normalized_key(seen_keys, normalized_key, original_value):
-    existing_value = seen_keys.get(normalized_key)
+def add_field_path_property(root_schema, field_path, record):
+    """
+    Supports paths like:
+      project.country_code
+      project.cobenefit_target[].cobenefit_type
+      project.cobenefit_target[].cobenefit_value
 
-    if existing_value is None:
-        seen_keys[normalized_key] = original_value
-    return existing_value
+    The first segment is treated as the top-level associated entity.
+    """
+    parts = [part.strip() for part in str(field_path).split(".") if part.strip()]
+    if len(parts) < 2:
+        return
+
+    current = root_schema
+
+    for i, raw_part in enumerate(parts):
+        is_last = i == len(parts) - 1
+        is_array = raw_part.endswith("[]")
+        part = raw_part.replace("[]", "")
+
+        if is_last:
+            current.setdefault("properties", {})[part] = build_field_schema(record)
+            if is_required(record.get("required_optional")):
+                add_required(current, part)
+            return
+
+        if is_array:
+            current.setdefault("properties", {})
+            if part not in current["properties"]:
+                current["properties"][part] = {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {},
+                        "required": [],
+                    },
+                }
+
+            current = current["properties"][part]["items"]
+
+        else:
+            current = ensure_object_property(current, part)
+
+
+def add_parent_field_property(root_schema, record):
+    entity = str(record.get("associated_entity")).strip()
+    field_name = str(record.get("field_name")).strip()
+    parent_field = record.get("parent_field")
+
+    entity_schema = ensure_object_property(root_schema, entity)
+
+    if not parent_field:
+        entity_schema["properties"][field_name] = build_field_schema(record)
+
+        if is_required(record.get("required_optional")):
+            add_required(entity_schema, field_name)
+
+        return
+
+    parent_field = str(parent_field).strip()
+    parent_schema = entity_schema["properties"].get(parent_field)
+
+    if parent_schema is None:
+        parent_schema = {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {},
+                "required": [],
+            },
+        }
+        entity_schema["properties"][parent_field] = parent_schema
+
+    item_schema = get_array_items_schema(parent_schema)
+
+    item_schema.setdefault("properties", {})[field_name] = build_field_schema(record)
+
+    if is_required(record.get("required_optional")):
+        add_required(item_schema, field_name)
 
 
 def worksheet_to_json_schema(ws):
     rows = list(ws.iter_rows(values_only=True))
-
     if not rows:
         return None
 
     headers = [normalize_header(header) for header in rows[0]]
 
-    required_columns = {
-        "associated_entity",
-        "field_name",
-        "datatype",
-    }
-
+    required_columns = {"associated_entity", "field_name", "datatype"}
     missing = required_columns - set(headers)
+
     if missing:
-        raise ValueError(
-            f"Sheet '{ws.title}' is missing required columns: {sorted(missing)}"
-        )
+        raise ValueError(f"Sheet '{ws.title}' is missing required columns: {sorted(missing)}")
 
     schema = {
         "$schema": JSON_SCHEMA_VERSION,
@@ -287,10 +336,7 @@ def worksheet_to_json_schema(ws):
         "required": [],
     }
 
-    required_by_entity = {}
-    entity_name_map = {}
-    field_name_maps_by_entity = {}
-
+    records = []
     for row in rows[1:]:
         record = {
             headers[i]: clean_value(row[i])
@@ -298,65 +344,36 @@ def worksheet_to_json_schema(ws):
             if headers[i]
         }
 
-        associated_entity = record.get("associated_entity")
-        field_name = record.get("field_name")
+        if record.get("associated_entity") and record.get("field_name"):
+            records.append(record)
 
-        if not associated_entity or not field_name:
-            continue
+    has_field_path = any(record.get("field_path") for record in records)
+    has_parent_logic = any(record.get("parent_field") or record.get("item_type") for record in records)
 
-        associated_entity = str(associated_entity).strip()
-        field_name = str(field_name).strip()
+    if has_field_path:
+        for record in records:
+            field_path = record.get("field_path")
+            if field_path:
+                add_field_path_property(schema, field_path, record)
+            else:
+                add_parent_field_property(schema, record)
 
-        entity_key = normalize_schema_key(associated_entity)
-        field_key = normalize_schema_key(field_name)
+    elif has_parent_logic:
+        parent_rows = [r for r in records if not r.get("parent_field")]
+        child_rows = [r for r in records if r.get("parent_field")]
 
-        if not entity_key:
-            raise ValueError(
-                f"Sheet '{ws.title}' has an associated_entity value that cannot be "
-                f"normalized into a JSON property name: '{associated_entity}'."
-            )
+        for record in parent_rows:
+            add_parent_field_property(schema, record)
 
-        if not field_key:
-            raise ValueError(
-                f"Sheet '{ws.title}' has a field_name value that cannot be "
-                f"normalized into a JSON property name: '{field_name}'."
-            )
+        for record in child_rows:
+            add_parent_field_property(schema, record)
 
-        register_normalized_key(
-            entity_name_map,
-            entity_key,
-            associated_entity,
-        )
+    else:
+        for record in records:
+            add_parent_field_property(schema, record)
 
-        if entity_key not in schema["properties"]:
-            schema["properties"][entity_key] = {
-                "type": "object",
-                "additionalProperties": False,
-                "properties": {},
-                "required": [],
-            }
-            required_by_entity[entity_key] = set()
-            field_name_maps_by_entity[entity_key] = {}
-
-        register_normalized_key(
-            field_name_maps_by_entity[entity_key],
-            field_key,
-            field_name,
-        )
-
-        schema["properties"][entity_key]["properties"][field_key] = build_field_schema(record)
-
-        if is_required(record.get("required_optional")):
-            required_by_entity[entity_key].add(field_key)
-
-    for entity_key, required_fields in required_by_entity.items():
-        schema["properties"][entity_key]["required"] = sorted(required_fields)
-
-    schema["required"] = sorted(
-        entity_key
-        for entity_key, required_fields in required_by_entity.items()
-        if required_fields
-    )
+   # schema["required"] = sorted(schema["properties"].keys())
+    schema.pop("required", None)
 
     return schema
 
@@ -374,7 +391,6 @@ def convert_workbook(input_file=INPUT_FILE, output_dir=OUTPUT_DIR):
 
     for ws in wb.worksheets:
         schema = worksheet_to_json_schema(ws)
-
         if schema is None:
             continue
 

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -293,7 +293,7 @@ def add_parent_field_property(root_schema, record):
 
         return
 
-    parent_field = str(parent_field).strip()
+    parent_field = normalize_header(parent_field)
     parent_schema = entity_schema["properties"].get(parent_field)
 
     if parent_schema is None:

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -372,7 +372,13 @@ def worksheet_to_json_schema(ws):
         for record in records:
             add_parent_field_property(schema, record)
 
-    schema["required"] = sorted(schema["properties"].keys())
+    schema["required"] = sorted(
+        entity
+        for entity, entity_schema in schema.get("properties", {}).items()
+        if entity_schema.get("required")
+    )
+    if not schema["required"]:
+        schema.pop("required", None)
 
     return schema
 

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -187,7 +187,7 @@ def build_field_schema(record):
     if datatype == "array" and item_type == "object":
         base_schema = {
             "type": "object",
-            "additionalProperties": False,
+            "additionalProperties": True,
             "properties": {},
             "required": [],
         }
@@ -201,7 +201,7 @@ def ensure_object_property(parent_schema, property_name):
     if property_name not in props:
         props[property_name] = {
             "type": "object",
-            "additionalProperties": False,
+            "additionalProperties": True,
             "properties": {},
             "required": [],
         }
@@ -222,7 +222,7 @@ def get_array_items_schema(array_schema):
 
     items = array_schema.setdefault("items", {
         "type": "object",
-        "additionalProperties": False,
+        "additionalProperties": True,
         "properties": {},
         "required": [],
     })
@@ -263,7 +263,7 @@ def add_field_path_property(root_schema, field_path, record):
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "additionalProperties": False,
+                        "additionalProperties": True,
                         "properties": {},
                         "required": [],
                     },
@@ -331,7 +331,7 @@ def worksheet_to_json_schema(ws):
         "$id": f"{safe_filename(ws.title)}.schema.json",
         "title": ws.title,
         "type": "object",
-        "additionalProperties": False,
+        "additionalProperties": True,
         "properties": {},
         "required": [],
     }

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -372,8 +372,7 @@ def worksheet_to_json_schema(ws):
         for record in records:
             add_parent_field_property(schema, record)
 
-   # schema["required"] = sorted(schema["properties"].keys())
-    schema.pop("required", None)
+    schema["required"] = sorted(schema["properties"].keys())
 
     return schema
 

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -276,8 +276,8 @@ def add_field_path_property(root_schema, field_path, record):
 
 
 def add_parent_field_property(root_schema, record):
-    entity = str(record.get("associated_entity")).strip()
-    field_name = str(record.get("field_name")).strip()
+    entity = normalize_header(record.get("associated_entity"))
+    field_name = normalize_header(record.get("field_name"))
     parent_field = record.get("parent_field")
 
     entity_schema = ensure_object_property(root_schema, entity)

--- a/scripts/generate_json_schemas.py
+++ b/scripts/generate_json_schemas.py
@@ -241,7 +241,10 @@ def add_field_path_property(root_schema, field_path, record):
     """
     parts = [part.strip() for part in str(field_path).split(".") if part.strip()]
     if len(parts) < 2:
-        return
+        raise ValueError(
+            f"Invalid field_path '{field_path}' for {record.get('associated_entity')}.{record.get('field_name')} "
+            f"(expected at least one '.' separator)"
+        )
 
     current = root_schema
 


### PR DESCRIPTION
# Summary

This PR adds conditional nesting functionality to the conversion script, based on the columns present in each tab of the XLSX reference file. This will allow for new schemas to be added with additional levels of depth, without requiring large refactors to existing XLSX tabs. This PR also updates additionalProperties to True across the board, allowing adopters to retain any custom fields. Documentation updates reflect these changes.

# Details

## Conversion Script

The conversion script now uses a three different conditions to identify any nesting requirements:
- If ```field_path``` is present, the script will rely on that column for all mapping. This field would denote the full hierarchy from top-level object to field_name, such as ```project.project_stakeholder[].project_stakeholder_name```
- If ```field_path``` is absent, the script looks for ```parent_field``` and ```item_type```. If present, these fields are used to identify single level nesting, placing ```field_name``` values with an associated ```parent_field``` as nested items within the ```parent_field``` array.
- If none of the above are present, the script falls back to the existing logic of ```associated_entity.field_name```

The conversion script also now allows all schema files to include additionalProperties to provide more flexibility and require less code changes for adopters.