### PR TITLE
Add validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,48 @@ Adoption of the tool lends to greater collaboration and data sharing across the 
 - **Project developers​**: Submitting data in CDOP format allows for more standardisation and less bespoke work for publishing project information.
 - **Ratings agencies and data providers​**: Adopt CDOP schemas for data ingestion of data can improve efficiency of data sharing and publishing.
 
-To allow for adoption, [this tool](https://cdop-schema-validator.lovable.app/) can be used to validate a payload against the various cdop schemas. This allows users to ensure their api interfaces are compatible. 
+## Validating Your Data
+
+CDOP provides two lightweight options for validating a JSON payload against the schemas locally.
+
+### Option 1 — Command-line tools
+
+Several off-the-shelf CLI validators support JSON Schema draft 2020-12. The examples below use [`check-jsonschema`](https://check-jsonschema.readthedocs.io/), which can be installed with pip:
+
+```bash
+pip install check-jsonschema
+```
+
+**Validate a single file:**
+```bash
+check-jsonschema --schemafile json_schema/Disclosures.schema.json my_disclosures.json
+```
+
+### Option 2 — Python validation script
+
+A helper script is included at `scripts/validate.py`. It requires Python 3.10+ and the `jsonschema` package:
+
+```bash
+pip install jsonschema
+```
+
+**Validate a data file:**
+```bash
+python scripts/validate.py my_data.json --schema json_schema/Issuances.schema.json
+```
+
+**Compare your own schema against the canonical CDOP schema:**
+```bash
+python scripts/validate.py my_schema.json --compare --schema json_schema/Disclosures.schema.json
+```
+
+The `--compare` flag treats the input file as a schema and checks it structurally against the canonical CDOP schema — same properties, types, and required fields. Cosmetic differences (descriptions, `$id`, `title`) are ignored. This is useful for confirming that a custom schema implementation stays in sync with the official CDOP definition.
+
+The script exits with code `0` on success and `1` on failure, making it easy to integrate into CI pipelines. Differences are printed with the JSON path and a description of each issue.
+
+### Legacy Schema Validation
+
+CDOP recommends following the canonical schemas and validation approaches above. However, if using legacy schemas, [this tool](https://cdop-schema-validator.lovable.app/) can be used to validate a payload.
 
 # Contributing Guidelines
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openpyxl >=3.0.0
+jsonschema >=4.18.0

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,203 @@
+"""
+Validate a JSON data file against a CDOP schema, or compare a schema file
+against the canonical CDOP schema.
+
+Usage:
+    python scripts/validate.py <data_file> --schema <schema_file>
+    python scripts/validate.py <schema_file> --compare --schema <canonical_schema>
+
+Examples:
+    # Validate data against a schema
+    python scripts/validate.py my_data.json --schema json_schema/Issuances.schema.json
+
+    # Compare a custom schema against the canonical CDOP schema
+    python scripts/validate.py my_schema.json --compare --schema json_schema/Disclosures.schema.json
+
+Requires:
+    pip install jsonschema
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+SCHEMA_DIR = pathlib.Path(__file__).parent.parent / "json_schema"
+
+# Fields considered cosmetic — ignored during structural comparison
+_COSMETIC_KEYS = {"description", "$id", "$schema", "title", "examples", "x-cdop-field-id"}
+
+
+def load_json(path: pathlib.Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: '{path}' is not valid JSON — {exc}")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Data validation
+# ---------------------------------------------------------------------------
+
+def validate(data_path: pathlib.Path, schema_path: pathlib.Path) -> bool:
+    try:
+        import jsonschema
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        print("ERROR: 'jsonschema' package is not installed.")
+        print("       Run:  pip install jsonschema")
+        sys.exit(1)
+
+    data = load_json(data_path)
+    schema = load_json(schema_path)
+
+    # Build a registry so $ref paths inside the schema directory resolve correctly
+    try:
+        from referencing import Registry, Resource
+        from referencing.jsonschema import DRAFT202012
+
+        def _load_resource(uri: str):
+            path = pathlib.Path(uri.replace("file:///", "").replace("file://", ""))
+            if path.exists():
+                return Resource.from_contents(load_json(path), default_specification=DRAFT202012)
+            raise jsonschema.exceptions.RefResolutionError(f"Cannot resolve: {uri}")
+
+        registry = Registry(retrieve=_load_resource)
+        validator = Draft202012Validator(schema, registry=registry)
+    except ImportError:
+        base_uri = schema_path.resolve().as_uri()
+        resolver = jsonschema.RefResolver(base_uri=base_uri, referrer=schema)
+        validator = Draft202012Validator(schema, resolver=resolver)
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+
+    if not errors:
+        print(f"OK  '{data_path}' is valid against '{schema_path.name}'.")
+        return True
+
+    print(f"FAIL  '{data_path}' has {len(errors)} validation error(s) against '{schema_path.name}':\n")
+    for i, error in enumerate(errors, 1):
+        path = " → ".join(str(p) for p in error.absolute_path) or "(root)"
+        print(f"  [{i}] {path}")
+        print(f"       {error.message}\n")
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Schema comparison
+# ---------------------------------------------------------------------------
+
+def _structural_keys(schema_node: dict) -> dict:
+    """Return a copy of a schema node with cosmetic keys removed."""
+    return {k: v for k, v in schema_node.items() if k not in _COSMETIC_KEYS}
+
+
+def _diff_schemas(user: object, canonical: object, path: str, diffs: list[str]) -> None:
+    """Recursively compare two schema nodes and append human-readable differences."""
+    if isinstance(canonical, dict) and isinstance(user, dict):
+        c = _structural_keys(canonical)
+        u = _structural_keys(user)
+
+        for key in sorted(c.keys() - u.keys()):
+            diffs.append(f"MISSING   {path}.{key}  (present in canonical schema)")
+
+        for key in sorted(u.keys() - c.keys()):
+            diffs.append(f"EXTRA     {path}.{key}  (not in canonical schema)")
+
+        for key in sorted(c.keys() & u.keys()):
+            _diff_schemas(u[key], c[key], f"{path}.{key}", diffs)
+
+    elif isinstance(canonical, list) and isinstance(user, list):
+        # For 'required' arrays: compare as sets (order doesn't matter)
+        if all(isinstance(x, str) for x in canonical + user):
+            missing = sorted(set(canonical) - set(user))
+            extra = sorted(set(user) - set(canonical))
+            if missing:
+                diffs.append(f"MISSING   {path}  values: {missing}")
+            if extra:
+                diffs.append(f"EXTRA     {path}  values: {extra}")
+        else:
+            if user != canonical:
+                diffs.append(f"CHANGED   {path}  expected {canonical!r}, got {user!r}")
+
+    else:
+        if user != canonical:
+            diffs.append(f"CHANGED   {path}  expected {canonical!r}, got {user!r}")
+
+
+def compare(user_schema_path: pathlib.Path, canonical_path: pathlib.Path) -> bool:
+    user_schema = load_json(user_schema_path)
+    canonical = load_json(canonical_path)
+
+    if not isinstance(user_schema, dict) or not isinstance(canonical, dict):
+        print("ERROR: Both files must be JSON objects.")
+        return False
+
+    diffs: list[str] = []
+    _diff_schemas(user_schema, canonical, "(root)", diffs)
+
+    if not diffs:
+        print(f"OK  '{user_schema_path}' matches the canonical '{canonical_path.name}' structurally.")
+        return True
+
+    print(
+        f"DIFF  '{user_schema_path}' differs from canonical '{canonical_path.name}'"
+        f" — {len(diffs)} structural difference(s):\n"
+    )
+    for d in diffs:
+        print(f"  {d}")
+    print()
+    return False
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a JSON data file against a CDOP schema, "
+            "or compare a schema file against the canonical CDOP schema."
+        )
+    )
+    parser.add_argument("data_file", help="Path to the JSON data or schema file")
+    parser.add_argument(
+        "--schema",
+        required=True,
+        help="Path to a CDOP schema file.",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help=(
+            "Compare the given file as a schema against the canonical CDOP schema "
+            "instead of validating it as data."
+        ),
+    )
+    args = parser.parse_args()
+
+    input_path = pathlib.Path(args.data_file)
+    if not input_path.exists():
+        print(f"ERROR: File not found: '{input_path}'")
+        sys.exit(1)
+
+    schema_path = pathlib.Path(args.schema)
+    if not schema_path.exists():
+        print(f"ERROR: Schema file not found: '{schema_path}'")
+        print(f"       Available schemas in '{SCHEMA_DIR}':")
+        for s in sorted(SCHEMA_DIR.glob("*.schema.json")):
+            print(f"         {s}")
+        sys.exit(1)
+
+    if args.compare:
+        ok = compare(input_path, schema_path)
+    else:
+        ok = validate(input_path, schema_path)
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -57,12 +57,19 @@ def validate(data_path: pathlib.Path, schema_path: pathlib.Path) -> bool:
         from referencing import Registry, Resource
         from referencing.jsonschema import DRAFT202012
 
+        from urllib.parse import unquote, urlparse
+        from urllib.request import url2pathname
+
         def _load_resource(uri: str):
-            path = pathlib.Path(uri.replace("file:///", "").replace("file://", ""))
+            parsed = urlparse(uri)
+            if parsed.scheme == "file":
+                path = pathlib.Path(url2pathname(unquote(parsed.path)))
+            else:
+                path = (schema_path.parent / uri).resolve()
+
             if path.exists():
                 return Resource.from_contents(load_json(path), default_specification=DRAFT202012)
-            raise jsonschema.exceptions.RefResolutionError(f"Cannot resolve: {uri}")
-
+            raise FileNotFoundError(f"Cannot resolve: {uri} (resolved to {path})")
         registry = Registry(retrieve=_load_resource)
         validator = Draft202012Validator(schema, registry=registry)
     except ImportError:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -70,7 +70,10 @@ def validate(data_path: pathlib.Path, schema_path: pathlib.Path) -> bool:
         resolver = jsonschema.RefResolver(base_uri=base_uri, referrer=schema)
         validator = Draft202012Validator(schema, resolver=resolver)
 
-    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    errors = sorted(
+        validator.iter_errors(data),
+        key=lambda e: "/".join(str(p) for p in e.absolute_path),
+    )
 
     if not errors:
         print(f"OK  '{data_path}' is valid against '{schema_path.name}'.")

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -100,7 +100,11 @@ def validate(data_path: pathlib.Path, schema_path: pathlib.Path) -> bool:
 
 def _structural_keys(schema_node: dict) -> dict:
     """Return a copy of a schema node with cosmetic keys removed."""
-    return {k: v for k, v in schema_node.items() if k not in _COSMETIC_KEYS}
+    return {
+        k: v
+        for k, v in schema_node.items()
+        if k not in _COSMETIC_KEYS and not k.startswith("x-cdop-")
+    }
 
 
 def _diff_schemas(user: object, canonical: object, path: str, diffs: list[str]) -> None:


### PR DESCRIPTION
# Summary

This PR adds `scripts/validate.py`, a script for end users to validate their own JSON schemas and data objects against the CDOP standard.

# Details

README updates: 
- Shift Lovable app reference to legacy note
- Add out of the box CLI option for validation
- Add examples for data JSON and JSON schema validation

requirements.txt updates:
- Add jsonschema library

`scripts/validate.py` creation:
- Given data or JSON schema, validate that all required properties and items are present with the appropriate data type
- Decorator fields are ignored
- Any missing or incorrectly formatted field is returned to the user