### PR TITLE
switch workflow to deploy key for bypass

### DIFF
--- a/.github/workflows/build-json-schemas.yml
+++ b/.github/workflows/build-json-schemas.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Swaps workflow to use deploy key rather than GitHub token to allow commit to main without PR or approval